### PR TITLE
Do not audit racey permission denials

### DIFF
--- a/gravity.te
+++ b/gravity.te
@@ -14,6 +14,7 @@ gen_require(`
   type var_t;
   type var_lib_t;
   type var_log_t;
+  type unlabeled_t;
 ')
 
 ####################################
@@ -171,9 +172,11 @@ seutil_domtrans_setfiles(gravity_domain)
 seutil_domtrans_semanage(gravity_domain)
 container_runtime_domtrans(gravity_domain)
 
-# planet process running as gravity_t
-# TODO: transition properly to gravity_container_runtime_t
-allow gravity_domain gravity_container_domain:key { create view setattr };
+# planet init
+# while planet is starting and has not been yet labeled
+dontaudit gravity_domain gravity_container_domain:key { create view setattr };
+dontaudit gravity_domain gravity_container_file_t:filesystem relabelto;
+dontaudit gravity_domain unlabeled_t:key create;
 allow gravity_domain self:fifo_file rw_fifo_file_perms;
 allow gravity_domain self:process { setrlimit setpgid ptrace setsched setkeycreate setexec transition };
 allow gravity_domain self:tcp_socket create_socket_perms;


### PR DESCRIPTION
Don't audit planet permission denials as long as the binary has not been labeled during initial startup.