### PR TITLE
A few more improvements

### DIFF
--- a/gravity.if
+++ b/gravity.if
@@ -10,13 +10,29 @@ interface(`gravity_home_content_filetrans',`
   files_search_home($1)
 ')
 
+########################################
+## <summary>
+##	Transition the specified type/role to gravity role.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+## <param name="role">
+## <summary>
+## 	Role allowed access.
+## </summary>
+## </param>
+#
 interface(`gravity_roletrans_gravity',`
   gen_require(`
     role gravity_roles;
-    type gravity_t, gravity_exec_t;
+    type gravity_exec_t, gravity_installer_exec_t;
   ')
   allow $1 gravity_roles;
   role_transition $1 gravity_exec_t gravity_roles;
+  role_transition $1 gravity_installer_exec_t gravity_roles;
   gravity_domtrans($2)
 ')
 
@@ -43,6 +59,38 @@ interface(`gravity_run',`
 
   gravity_domtrans($1)
   roleattribute $2 gravity_roles;
+')
+
+########################################
+## <summary>
+##	Enable the specified type/role to use gravity.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+## <param name="role">
+## <summary>
+## 	Role allowed access.
+## </summary>
+## </param>
+#
+interface(`gravity_run_to',`
+  gen_require(`
+    role system_r;
+    attribute gravity_domain;
+    attribute gravity_container_domain;
+    type gravity_exec_t, gravity_installer_exec_t;
+  ')
+
+  can_exec($1, gravity_executable_domain)
+  gravity_domtrans($1)
+  gravity_installer_domtrans($1)
+  role $2 types gravity_domain;
+  role $2 types gravity_container_domain;
+  role_transition $2 gravity_exec_t system_r;
+  role_transition $2 gravity_installer_exec_t system_r;
 ')
 
 ########################################
@@ -128,6 +176,27 @@ interface(`gravity_installer_domtrans',`
   corecmd_search_bin($1)
   domtrans_pattern($1, gravity_installer_exec_t, gravity_installer_t)
 ')
+
+########################################
+## <summary>
+##	Execute kubernetes tools in the specified domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`gravity_kubernetes_domtrans',`
+  gen_require(`
+    type gravity_kubernetes_t, gravity_kubernetes_exec_t;
+  ')
+
+  corecmd_search_bin($1)
+  domtrans_pattern($1, gravity_kubernetes_exec_t, gravity_kubernetes_t)
+')
+
+
 
 ######################################
 ## <summary>
@@ -428,8 +497,7 @@ interface(`gravity_manage_executable_content',`
     attribute gravity_executable_domain;
   ')
 
-  # TODO
-  allow $1 gravity_executable_domain:file { setattr unlink };
+  manage_files_pattern($1, gravity_executable_domain, gravity_executable_domain)
 ')
 
 ########################################

--- a/gravity.te
+++ b/gravity.te
@@ -12,6 +12,7 @@ gen_require(`
   type container_runtime_tmpfs_t;
   type spc_t;
   type var_t;
+  type etc_t;
   type var_lib_t;
   type var_log_t;
   type unlabeled_t;
@@ -62,12 +63,10 @@ attribute gravity_port_type;
 type gravity_port_t, gravity_port_type;
 type gravity_install_port_t, gravity_port_type;
 type gravity_vxlan_port_t, gravity_port_type;
-type gravity_docker_port_t, gravity_port_type;
 type gravity_kubernetes_port_t, gravity_port_type;
 corenet_port(gravity_port_t)
 corenet_port(gravity_install_port_t)
 corenet_port(gravity_vxlan_port_t)
-corenet_port(gravity_docker_port_t)
 corenet_port(gravity_kubernetes_port_t)
 
 #####################################
@@ -139,6 +138,7 @@ role gravity_roles types gravity_container_runtime_t;
 # Local policy
 #
 
+userdom_use_user_terminals(gravity_domain)
 can_exec(gravity_domain, gravity_exec_t)
 can_exec(gravity_domain, gravity_installer_exec_t)
 can_exec(gravity_domain, gravity_container_file_t)
@@ -366,33 +366,23 @@ logging_send_syslog_msg(gravity_installer_t)
 optional_policy(`
   gen_require(`
     role unconfined_r;
+    type unconfined_t;
   ')
-  unconfined_run_to(gravity_t, gravity_exec_t)
-  unconfined_run_to(gravity_installer_t, gravity_installer_exec_t)
-  role_transition unconfined_r gravity_exec_t system_r;
-  role_transition unconfined_r gravity_installer_exec_t system_r;
+  gravity_run_to(unconfined_t, unconfined_r)
 ')
-
 optional_policy(`
   gen_require(`
     role sysadm_r;
     type sysadm_t;
   ')
-  gravity_run(sysadm_t, sysadm_r)
-  gravity_installer_domtrans(sysadm_t)
-  role_transition sysadm_r gravity_exec_t system_r;
-  role_transition sysadm_r gravity_installer_exec_t system_r;
+  gravity_run_to(sysadm_t, sysadm_r)
 ')
-
 optional_policy(`
   gen_require(`
     role staff_r;
     type staff_t;
   ')
-  gravity_run(staff_t, staff_r)
-  gravity_installer_domtrans(staff_t)
-  role_transition staff_r gravity_exec_t system_r;
-  role_transition staff_r gravity_installer_exec_t system_r;
+  gravity_run_to(staff_t, staff_r)
 ')
 
 allow gravity_domain self:capability { sys_ptrace sys_admin sys_resource chown fowner fsetid setuid setgid setpcap sys_chroot };
@@ -430,6 +420,8 @@ files_dontaudit_write_root_dirs(gravity_domain)
 #
 # gravity installer
 #
+
+gravity_domtrans(gravity_installer_t)
 # switch the role to system_r when restarting
 domain_role_change_exemption(gravity_installer_t)
 domain_system_change_exemption(gravity_installer_t)
@@ -598,20 +590,21 @@ optional_policy(`
     type faillog_t;
     type lastlog_t;
     type wtmp_t;
-    type etc_t;
   ')
-  allow gravity_domain etc_t:lnk_file unlink;
   allow gravity_domain faillog_t:file unlink;
   allow gravity_domain lastlog_t:file unlink;
   allow gravity_domain wtmp_t:file unlink;
   allow gravity_container_t faillog_t:file { read_file_perms };
 ')
+allow gravity_domain etc_t:lnk_file unlink;
 # ls/lsof/cat support for the above
 auth_read_passwd(gravity_container_t)
 auth_read_shadow(gravity_container_t)
 auth_read_login_records(gravity_container_t)
 auth_read_lastlog(gravity_container_t)
 fs_getattr_xattr_fs(gravity_container_t)
+# allow rm to remove docker network directory
+allow gravity_container_t container_var_lib_t:file unlink;
 
 # systemd-tmpfiles
 # ================


### PR DESCRIPTION
 * Move user/role-specific setup to the new `gravity_run_to` macro. The new macro also fixes permission issues for `sysadm` when working with `kubectl` on host.
 * Fix permissions to enable `gravity_installer_t` to manage files in planet rootfs (i.e. when rolling back system upgrades)
 * Remove unused docker port type
 * Allow `rm` inside the planet container to remove `/ext/docker/network` as a ExecStartPre command
