### PR TITLE
Fix external build failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-MODULES?=${TARGETS:=.pp.bz2}
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+CURRENT_DIR := $(realpath $(patsubst %/,%,$(dir $(MKFILE_PATH))))
+MODULES?=$(TARGETS:=.pp.bz2)
 SHAREDIR?=/usr/share
 AWSCLI?=aws
-OUTPUT?=output
-TARGETS:=$(OUTPUT)/container $(OUTPUT)/gravity
+OUTPUTDIR?=output
+TARGETS:=$(OUTPUTDIR)/container $(OUTPUTDIR)/gravity
 SOURCES=gravity.te gravity.if gravity.fc
 CONTAINER_BUILD_ARGS?=
 OUTPUT_GROUP?=$(shell id -g)
@@ -17,23 +19,24 @@ COPY:=cp
 
 all: build
 
-$(OUTPUT)/%.pp.bz2: $(OUTPUT)/%.pp | $(OUTPUT)
+$(OUTPUTDIR)/%.pp.bz2: $(OUTPUTDIR)/%.pp | $(OUTPUTDIR)
 	@echo Compressing $^ -\> $@
 	bzip2 -f -9 -c $^ > $@
+	rm -f $^
 	chown $(OUTPUT_OWNER):$(OUTPUT_GROUP) $@
 
-$(OUTPUT)/gravity.pp: $(SOURCES) | $(OUTPUT)
-	make -f ${SHAREDIR}/selinux/devel/Makefile $(@F)
+$(OUTPUTDIR)/gravity.pp: $(SOURCES) | $(OUTPUTDIR)
+	make -f $(SHAREDIR)/selinux/devel/Makefile $(@F)
 	install -D --group $(OUTPUT_GROUP) --owner $(OUTPUT_OWNER) $(@F) $@
-	make -f ${SHAREDIR}/selinux/devel/Makefile clean
+	make -f $(SHAREDIR)/selinux/devel/Makefile clean
 
-$(OUTPUT)/container.pp: $(CONTAINER_SOURCES) | $(OUTPUT)
-	make -f ${SHAREDIR}/selinux/devel/Makefile $(@F)
-	install -D -m 644 container-selinux/container.if ${DESTDIR}${SHAREDIR}/selinux/devel/include/services/container.if
+$(OUTPUTDIR)/container.pp: $(CONTAINER_SOURCES) | $(OUTPUTDIR)
+	make -f $(SHAREDIR)/selinux/devel/Makefile $(@F)
+	install -D -m 644 container-selinux/container.if $(DESTDIR)$(SHAREDIR)/selinux/devel/include/services/container.if
 	install -D --group $(OUTPUT_GROUP) --owner $(OUTPUT_OWNER) $(@F) $@
-	make -f ${SHAREDIR}/selinux/devel/Makefile clean
+	make -f $(SHAREDIR)/selinux/devel/Makefile clean
 
-$(OUTPUT)/gravity.statedir.fc.template: $(OUTPUT)/gravity.pp
+$(OUTPUTDIR)/gravity.statedir.fc.template: $(OUTPUTDIR)/gravity.pp
 	install -D --group $(OUTPUT_GROUP) --owner $(OUTPUT_OWNER) $(@F) $@
 
 gravity.fc: gravity.fc.template gravity.statedir.fc.template values.toml
@@ -42,48 +45,48 @@ gravity.fc: gravity.fc.template gravity.statedir.fc.template values.toml
 
 .PHONY: clean
 clean:
-	rm -f *~ *.tc $(OUTPUT)/*.pp $(OUTPUT)/*.pp.bz2 $(OUTPUT)/gravity.statedir.fc.template
+	rm -f *~ *.tc $(OUTPUTDIR)/*.pp* $(OUTPUTDIR)/gravity.statedir.fc.template
 	rm -f container-selinux/*~ container-selinux/*.tc
 	rm -rf tmp *.tar.gz
 
 .PHONY: man
 man: install-policy
-	sepolicy manpage --path . --domain ${TARGETS}_t
+	sepolicy manpage --path . --domain $(TARGETS)_t
 
 .PHONY: install-policy
 install-policy: all
-	semodule -i ${TARGETS}.pp.bz2
+	semodule -i $(TARGETS).pp.bz2
 
 .PHONY: install
 install: man
-	install -D -m 644 ${TARGETS}.pp.bz2 ${DESTDIR}${SHAREDIR}/selinux/packages/
-	install -D -m 644 container-selinux/container.if ${DESTDIR}${SHAREDIR}/selinux/devel/include/services/container.if
-	install -D -m 644 gravity.if ${DESTDIR}${SHAREDIR}/selinux/devel/include/services/gravity.if
-	install -D -m 644 container-selinux/container_selinux.8 ${DESTDIR}${SHAREDIR}/man/man8/
+	install -D -m 644 $(TARGETS).pp.bz2 $(DESTDIR)$(SHAREDIR)/selinux/packages/
+	install -D -m 644 container-selinux/container.if $(DESTDIR)$(SHAREDIR)/selinux/devel/include/services/container.if
+	install -D -m 644 gravity.if $(DESTDIR)$(SHAREDIR)/selinux/devel/include/services/gravity.if
+	install -D -m 644 container-selinux/container_selinux.8 $(DESTDIR)$(SHAREDIR)/man/man8/
 
 .PHONY: build
 build: buildbox
-	${CONTAINER_RUNTIME} run \
-		--name=${BUILDBOX_INSTANCE} \
+	$(CONTAINER_RUNTIME) run \
+		--name=$(BUILDBOX_INSTANCE) \
 		--privileged \
-		-v ${PWD}:/src \
-		--env "OUTPUT_GROUP=${OUTPUT_GROUP}" \
-		--env "OUTPUT_OWNER=${OUTPUT_OWNER}" \
-		--rm ${BUILDBOX} \
-		make ${TARGETS:=.pp.bz2} $(OUTPUT)/gravity.statedir.fc.template
+		-v $(CURRENT_DIR):/src \
+		--env "OUTPUT_GROUP=$(OUTPUT_GROUP)" \
+		--env "OUTPUT_OWNER=$(OUTPUT_OWNER)" \
+		--rm $(BUILDBOX) \
+		make $(TARGETS:=.pp.bz2) $(OUTPUTDIR)/gravity.statedir.fc.template
 
 .PHONY: buildbox
 buildbox:
-	${CONTAINER_RUNTIME} build -t ${BUILDBOX} ${CONTAINER_BUILD_ARGS} -f $(DOCKERFILE) .
+	$(CONTAINER_RUNTIME) build -t $(BUILDBOX) $(CONTAINER_BUILD_ARGS) -f $(DOCKERFILE) .
 
 .PHONY: publish
 publish: build
-	$(AWSCLI) s3 cp ${S3_OPTS} ${TARGETS:=.pp.bz2} ${BUILD_BUCKET_URL}/selinux-policy/centos/${VERSION}/
+	$(AWSCLI) s3 cp $(S3_OPTS) $(TARGETS:=.pp.bz2) $(BUILD_BUCKET_URL)/selinux-policy/centos/$(VERSION)/
 
 .PHONY: get-version
 get-version:
-	@echo ${VERSION}
+	@echo $(VERSION)
 
-$(OUTPUT):
+$(OUTPUTDIR):
 	mkdir -p $@
 	chown $(OUTPUT_OWNER):$(OUTPUT_GROUP) $@


### PR DESCRIPTION
Fixes the following issue when the package is built as external dependency (in magent-driven build pipeline):
```
docker run \
        --name= \
        --privileged \
        -v /home/user/go/src/github.com/gravitational/gravity:/src \
        --env "OUTPUT_GROUP=1000" \
        --env "OUTPUT_OWNER=1000" \
        --rm selinux-dev:centos7 \
        make output/container.pp.bz2 output/gravity.pp.bz2 output/gravity.statedir.fc.template
./version.sh: line 24: git: command not found
./version.sh: line 25: git: command not found
./version.sh: line 26: git: command not found
./version.sh: line 27: git: command not found
./version.sh: line 24: git: command not found
./version.sh: line 25: git: command not found
./version.sh: line 26: git: command not found
./version.sh: line 27: git: command not found

...
make: *** No rule to make target `output/container.pp.bz2'.  Stop.
```
Also addresses a handful of styling inconsistencies.

Complements https://github.com/gravitational/gravity/pull/2539.